### PR TITLE
Fix/findtxtrec

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -335,12 +335,12 @@ func findTxtRecord(client *GoDNSMadeEasy.GoDMEConfig, domainID int, zone, fqdn s
 	for _, existingRecord := range records {
 		// Remove quotas from Record.Value
 		truncateStr := "\""
-		recordValue := strings.TrimPrefix(existingRecord.Value, truncateStr)
-		recordValue = strings.TrimSuffix(recordValue, truncateStr)
+		unquotedRecordValue := strings.TrimPrefix(existingRecord.Value, truncateStr)
+		unquotedRecordValue = strings.TrimSuffix(unquotedRecordValue, truncateStr)
 
 		if existingRecord.Name == name &&
 			existingRecord.Type == "TXT" &&
-			recordValue == key {
+			unquotedRecordValue == key {
 			fmt.Printf("DNS record found: %v\n", existingRecord)
 			return &existingRecord
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -333,9 +333,14 @@ func findTxtRecord(client *GoDNSMadeEasy.GoDMEConfig, domainID int, zone, fqdn s
 	}
 
 	for _, existingRecord := range records {
+		// Remove quotas from Record.Value
+		truncateStr := "\""
+		recordValue := strings.TrimPrefix(existingRecord.Value, truncateStr)
+		recordValue = strings.TrimSuffix(recordValue, truncateStr)
+
 		if existingRecord.Name == name &&
 			existingRecord.Type == "TXT" &&
-			existingRecord.Value == key {
+			recordValue == key {
 			fmt.Printf("DNS record found: %v\n", existingRecord)
 			return &existingRecord
 		}


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove quotes from TXT Record.Value in findTxtRecord function.

**Benefits**

<!-- What benefits will be realized by the code change? -->

CleanUp function calls DeleteRecord function only if findTxtRecord function returns not nil value.

Dnsmadeeasy API returns TXT resourse Record.Value as quoted string `"OVUqJa_VNbwP25YohuGXa7LHQc5KUJrIizCn9awAlGQ"` while TXT record key variable is not quoted  `OVUqJa_VNbwP25YohuGXa7LHQc5KUJrIizCn9awAlGQ`

For example: `{_acme-challenge.test02.lab "OVUqJa_VNbwP25YohuGXa7LHQc5KUJrIizCn9awAlGQ" 190182233 TXT false false DEFAULT false 600 false false 7765239 1 0 0 0 0    }`

DeleteRecord function never calls. TXT record never removes.

Removing quotes from API response value - solves the issue.
